### PR TITLE
[AUTH] [KAN-11] 로그인과 회원가입 페이지 구현

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -1,8 +1,8 @@
 import { RecoilRoot } from 'recoil';
 import { QueryClient, QueryClientProvider } from 'react-query';
 import Router from './Router';
-import Header from './components/Header';
-import { Center } from './components/Default/styled';
+import Layout from './layout';
+import { BrowserRouter } from 'react-router-dom';
 
 const queryClient = new QueryClient();
 
@@ -10,10 +10,11 @@ function App() {
     return (
         <RecoilRoot>
             <QueryClientProvider client={queryClient}>
-                <Header />
-                <Center>
-                    <Router />
-                </Center>
+                <BrowserRouter>
+                    <Layout>
+                        <Router />
+                    </Layout>
+                </BrowserRouter>
             </QueryClientProvider>
         </RecoilRoot>
     );

--- a/src/Router.js
+++ b/src/Router.js
@@ -15,6 +15,7 @@ import ShortFormRegisterPage from './pages/ShortFormRegister';
 import PrologueRegisterPage from './pages/PrologueRegister';
 import PrologueDetailPage from './pages/PrologueDetail';
 import LoginPage from './pages/Login';
+import SignUpPage from './pages/SignUp';
 
 const Router = () => {
     return (
@@ -31,6 +32,7 @@ const Router = () => {
             <Route path="/suggestion" element={<Suggestion />} />
             <Route path="/studio" element={<Studio />} />
             <Route path="/login" element={<LoginPage />} />
+            <Route path="/signup" element={<SignUpPage />} />
         </Routes>
     );
 };

--- a/src/Router.js
+++ b/src/Router.js
@@ -18,24 +18,20 @@ import LoginPage from './pages/Login';
 
 const Router = () => {
     return (
-        <BrowserRouter>
-            <Sidebar />
-            <Routes>
-                <Route path="/" element={<Main />} />
-                <Route path="/shortForm" element={<ShortForm />} />
-                <Route path="/shortForm/register" element={<ShortFormRegisterPage />} />
-                <Route path="/lesson" element={<Lesson />} />
-                <Route path="/lesson/register" element={<LessonRegisterPage />} />
-                <Route path="/craft" element={<Craft />} />
-                <Route path="/prologue" element={<Prologue />} />
-                <Route path="/prologue/:prologueThemeId" element={<PrologueDetailPage />} />
-                <Route path="/prologue/register" element={<PrologueRegisterPage />} />
-                <Route path="/suggestion" element={<Suggestion />} />
-                <Route path="/studio" element={<Studio />} />
-                <Route path="/login" element={<LoginPage />} />
-            </Routes>
-            {/* </Center> */}
-        </BrowserRouter>
+        <Routes>
+            <Route path="/" element={<Main />} />
+            <Route path="/shortForm" element={<ShortForm />} />
+            <Route path="/shortForm/register" element={<ShortFormRegisterPage />} />
+            <Route path="/lesson" element={<Lesson />} />
+            <Route path="/lesson/register" element={<LessonRegisterPage />} />
+            <Route path="/craft" element={<Craft />} />
+            <Route path="/prologue" element={<Prologue />} />
+            <Route path="/prologue/:prologueThemeId" element={<PrologueDetailPage />} />
+            <Route path="/prologue/register" element={<PrologueRegisterPage />} />
+            <Route path="/suggestion" element={<Suggestion />} />
+            <Route path="/studio" element={<Studio />} />
+            <Route path="/login" element={<LoginPage />} />
+        </Routes>
     );
 };
 

--- a/src/Router.js
+++ b/src/Router.js
@@ -14,11 +14,11 @@ import LessonRegisterPage from './pages/LessonRegister';
 import ShortFormRegisterPage from './pages/ShortFormRegister';
 import PrologueRegisterPage from './pages/PrologueRegister';
 import PrologueDetailPage from './pages/PrologueDetail';
+import LoginPage from './pages/Login';
 
 const Router = () => {
     return (
         <BrowserRouter>
-            {/* <Center> */}
             <Sidebar />
             <Routes>
                 <Route path="/" element={<Main />} />
@@ -32,6 +32,7 @@ const Router = () => {
                 <Route path="/prologue/register" element={<PrologueRegisterPage />} />
                 <Route path="/suggestion" element={<Suggestion />} />
                 <Route path="/studio" element={<Studio />} />
+                <Route path="/login" element={<LoginPage />} />
             </Routes>
             {/* </Center> */}
         </BrowserRouter>

--- a/src/apis/Auth/index.js
+++ b/src/apis/Auth/index.js
@@ -3,3 +3,7 @@ import instance from '..';
 export const LoginAPI = (loginRegister) => {
     return instance.post('/auth/login', loginRegister);
 };
+
+export const SignUpAPI = (signUpRegister) => {
+    return instance.post('/auth/signup', signUpRegister);
+};

--- a/src/apis/Auth/index.js
+++ b/src/apis/Auth/index.js
@@ -1,0 +1,5 @@
+import instance from '..';
+
+export const LoginAPI = (loginRegister) => {
+    return instance.post('/auth/login', loginRegister);
+};

--- a/src/components/Button/styled.js
+++ b/src/components/Button/styled.js
@@ -84,6 +84,15 @@ const buttonStyles = {
             background-color: ${({ disabled }) => (disabled ? colors.light_gray : colors.main_green)};
         }
     `,
+    logoutBtn: css`
+        font-size: 15px;
+        font-family: 'Happiness-Sans', sans-serif;
+        font-weight: 700; /* Bold */
+        border: none;
+        background-color: transparent;
+        font-size: 15px;
+        color: ${colors.white};
+    `,
 };
 
 export const StyledButton = styled.button`

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -27,7 +27,9 @@ const Header = () => {
                         LOGOUT
                     </Button>
                 ) : (
-                    <StyledLink to="/login">LOGIN</StyledLink>
+                    <>
+                        <StyledLink to="/login">LOGIN</StyledLink>/<StyledLink to="/signup">SIGNUP</StyledLink>
+                    </>
                 )}
             </RightWrapper>
         </Container>

--- a/src/components/Header/index.jsx
+++ b/src/components/Header/index.jsx
@@ -1,13 +1,35 @@
 import React, { useState } from 'react';
-import { Container, LeftWrapper, LogoImage } from './styled';
+import { Container, LeftWrapper, LogoImage, RightWrapper, StyledLink } from './styled';
 
 import logo from '../../assets/images/logo.svg';
+import { useRecoilValue, useSetRecoilState } from 'recoil';
+import { authState } from '../../recoil';
+import Button from '../Button';
 
 const Header = () => {
+    const isAuthenticated = useRecoilValue(authState);
+    const setAuthState = useSetRecoilState(authState);
+
+    const handleLogout = () => {
+        setAuthState(false);
+    };
+
     return (
         <Container>
-            <LogoImage src={logo} />
-            <LeftWrapper>관리자페이지입니다!</LeftWrapper>
+            <LeftWrapper>
+                <LogoImage src={logo} />
+                관리자페이지입니다!
+            </LeftWrapper>
+            <RightWrapper>
+                {/* hello! */}
+                {isAuthenticated ? (
+                    <Button variant="logoutBtn" onClick={handleLogout}>
+                        LOGOUT
+                    </Button>
+                ) : (
+                    <StyledLink to="/login">LOGIN</StyledLink>
+                )}
+            </RightWrapper>
         </Container>
     );
 };

--- a/src/components/Header/styled.js
+++ b/src/components/Header/styled.js
@@ -36,6 +36,7 @@ export const RightWrapper = styled.div`
     display: flex;
     // width: 100px;
     margin: 10px;
+    gap: 10px;
     color: ${colors.white};
     align-items: center;
     justify-context: center;

--- a/src/components/Header/styled.js
+++ b/src/components/Header/styled.js
@@ -1,16 +1,19 @@
 import styled from 'styled-components';
 import { colors } from '../../styles/colors';
 import '../../styles/font.css';
+import { Link } from 'react-router-dom';
 
 export const Container = styled.div`
     display: flex;
+    justify-content: space-between;
     align-items: center;
     width: 100%;
     height: 10vh;
-    padding-left: 20px;
+    padding: 22px;
+    box-sizing: border-box;
     font-family: 'Happiness-Sans', sans-serif;
     font-weight: 700; /* Bold */
-    background-color: ${colors.side_bar};
+    background-color: ${colors.main_green};
 `;
 
 export const LogoImage = styled.img`
@@ -20,9 +23,34 @@ export const LogoImage = styled.img`
 
 export const LeftWrapper = styled.div`
     display: flex;
-    margin: 10px;
+    // margin: 10px;
+    gap: 22px;
     color: ${colors.white};
     align-items: center;
     font-family: 'Happiness-Sans', sans-serif;
     font-weight: 700; /* Bold */
+    // background-color: ${colors.white};
+`;
+
+export const RightWrapper = styled.div`
+    display: flex;
+    // width: 100px;
+    margin: 10px;
+    color: ${colors.white};
+    align-items: center;
+    justify-context: center;
+    font-family: 'Happiness-Sans', sans-serif;
+    font-weight: 700; /* Bold */
+`;
+
+export const StyledLink = styled(Link)`
+    text-decoration: none; /* 기본 밑줄 제거 */
+    color: inherit; /* 상위 요소의 색상 상속 */
+    font-size: 15px;
+    font-family: 'Happiness-Sans', sans-serif;
+    font-weight: 700; /* Bold */
+    &:hover {
+        color: inherit; /* hover 상태에서 색상 변경 없음 */
+        text-decoration: none; /* hover 상태에서도 밑줄 없음 */
+    }
 `;

--- a/src/components/Login/index.jsx
+++ b/src/components/Login/index.jsx
@@ -1,15 +1,45 @@
 import React from 'react';
-import { Checkbox, Form, Input } from 'antd';
+import { notification } from 'antd';
 import Button from '../Button';
 import { StyledForm, StyledFormItem, StyledInput, StyledPassword } from './styled';
-const onFinish = (values) => {
-    console.log('Success:', values);
-};
-const onFinishFailed = (errorInfo) => {
-    console.log('Failed:', errorInfo);
-};
+import { useRecoilState } from 'recoil';
+import { authState } from '../../recoil';
+import { LoginAPI } from '../../apis/Auth';
+import { useNavigate } from 'react-router';
 
 const CustomLogin = () => {
+    const navigate = useNavigate();
+    const [isLoggedIn, setIsLoggedIn] = useRecoilState(authState);
+
+    const onFinish = async (values) => {
+        console.log('들어옴?');
+        try {
+            const loginRequest = {
+                username: values.username,
+                password: values.password,
+            };
+            // 로그인 API 요청
+            console.log('LoginAPI loginRequest : ', loginRequest);
+            const response = await LoginAPI(loginRequest);
+            console.log('LoginAPI response : ', response);
+            if (response.data.success) {
+                // 로그인 성공 시 localStorage에 저장
+                localStorage.setItem('isLoggedIn', 'true');
+                setIsLoggedIn(true);
+                notification.success({ message: 'Login successful!' }); // 성공 알림
+                navigate('/lesson');
+            } else {
+                notification.error({ message: 'Login failed. Please try again.' }); // 실패 알림
+            }
+        } catch (error) {
+            console.error('Login error:', error);
+            notification.error({ message: 'An error occurred. Please try again.' }); // 오류 알림
+        }
+    };
+    const onFinishFailed = (errorInfo) => {
+        console.log('Failed:', errorInfo);
+    };
+
     return (
         <StyledForm onFinish={onFinish} onFinishFailed={onFinishFailed} autoComplete="off">
             <StyledFormItem
@@ -37,17 +67,7 @@ const CustomLogin = () => {
             >
                 <StyledPassword />
             </StyledFormItem>
-
-            <StyledFormItem
-                name="remember"
-                valuePropName="checked"
-                wrapperCol={{
-                    offset: 8,
-                    span: 16,
-                }}
-            ></StyledFormItem>
-
-            <Button variant="registerBtn" htmlType="submit">
+            <Button variant="registerBtn" type="submit">
                 로그인
             </Button>
         </StyledForm>

--- a/src/components/Login/index.jsx
+++ b/src/components/Login/index.jsx
@@ -1,0 +1,56 @@
+import React from 'react';
+import { Checkbox, Form, Input } from 'antd';
+import Button from '../Button';
+import { StyledForm, StyledFormItem, StyledInput, StyledPassword } from './styled';
+const onFinish = (values) => {
+    console.log('Success:', values);
+};
+const onFinishFailed = (errorInfo) => {
+    console.log('Failed:', errorInfo);
+};
+
+const CustomLogin = () => {
+    return (
+        <StyledForm onFinish={onFinish} onFinishFailed={onFinishFailed} autoComplete="off">
+            <StyledFormItem
+                label="아이디"
+                name="username"
+                rules={[
+                    {
+                        required: true,
+                        message: '아이디를 입력해주세요.',
+                    },
+                ]}
+            >
+                <StyledInput />
+            </StyledFormItem>
+
+            <StyledFormItem
+                label="비밀번호"
+                name="password"
+                rules={[
+                    {
+                        required: true,
+                        message: '비밀번호를 입력해주세요.',
+                    },
+                ]}
+            >
+                <StyledPassword />
+            </StyledFormItem>
+
+            <StyledFormItem
+                name="remember"
+                valuePropName="checked"
+                wrapperCol={{
+                    offset: 8,
+                    span: 16,
+                }}
+            ></StyledFormItem>
+
+            <Button variant="registerBtn" htmlType="submit">
+                로그인
+            </Button>
+        </StyledForm>
+    );
+};
+export default CustomLogin;

--- a/src/components/Login/styled.js
+++ b/src/components/Login/styled.js
@@ -1,4 +1,4 @@
-import { Form, Input, Button } from 'antd';
+import { Form, Input } from 'antd';
 import styled from 'styled-components';
 import { colors } from '../../styles/colors';
 

--- a/src/components/Login/styled.js
+++ b/src/components/Login/styled.js
@@ -1,0 +1,45 @@
+import { Form, Input, Button } from 'antd';
+import styled from 'styled-components';
+import { colors } from '../../styles/colors';
+
+// Styled Components
+export const StyledForm = styled(Form)`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto;
+    padding: 20px;
+    width: 100%;
+    // background-color: #f5f5f5;
+    border-radius: 8px;
+`;
+
+export const StyledFormItem = styled(Form.Item)`
+    margin-bottom: 24px;
+    // background-color: ${colors.main_green};
+    label {
+        font-size: 18px;
+        font-family: 'Happiness-Sans', sans-serif;
+        font-weight: 400; /* Bold */
+        color: ${colors.black};
+        width: 100px;
+        // background-color: ${colors.drak_gray};
+    }
+`;
+
+export const StyledInput = styled(Input)`
+    padding: 8px;
+    width: 300px;
+    height: 50px;
+    border-radius: 10px;
+    border: 1px solid ${colors.gray};
+`;
+
+export const StyledPassword = styled(Input.Password)`
+    padding: 8px;
+    width: 300px;
+    height: 50px;
+    border-radius: 10px;
+    border: 1px solid ${colors.gray};
+`;

--- a/src/components/SignUp/index.jsx
+++ b/src/components/SignUp/index.jsx
@@ -1,0 +1,90 @@
+import React from 'react';
+import { notification } from 'antd';
+import Button from '../Button';
+import { StyledForm, StyledFormItem, StyledInput, StyledPassword } from './styled';
+import { useRecoilState } from 'recoil';
+import { authState } from '../../recoil';
+import { LoginAPI, SignUpAPI } from '../../apis/Auth';
+import { useNavigate } from 'react-router';
+
+const CustomSignUp = () => {
+    const navigate = useNavigate();
+
+    const onFinish = async (values) => {
+        console.log('들어옴?');
+        try {
+            const signUpRequest = {
+                username: values.username,
+                password: values.password,
+                name: values.name,
+                memberRole: 0,
+            };
+            // 로그인 API 요청
+            console.log('SignUpAPI signUpRequest : ', Request);
+            const response = await SignUpAPI(signUpRequest);
+            console.log('SignUpAPI response : ', response);
+            if (response.data.success) {
+                // 로그인 성공 시 localStorage에 저장
+                localStorage.setItem('signUp success', 'true');
+                notification.success({ message: 'SignUpAPI successful!' }); // 성공 알림
+                navigate('/login');
+            } else {
+                notification.error({ message: 'SignUpAPI failed. Please try again.' }); // 실패 알림
+            }
+        } catch (error) {
+            console.error('SignUpAPI error:', error);
+            notification.error({ message: 'An error occurred. Please try again.' }); // 오류 알림
+        }
+    };
+    const onFinishFailed = (errorInfo) => {
+        console.log('Failed:', errorInfo);
+    };
+
+    return (
+        <StyledForm onFinish={onFinish} onFinishFailed={onFinishFailed} autoComplete="off">
+            <StyledFormItem
+                label="아이디"
+                name="username"
+                rules={[
+                    {
+                        required: true,
+                        message: '아이디를 입력해주세요.',
+                    },
+                ]}
+            >
+                <StyledInput />
+            </StyledFormItem>
+
+            <StyledFormItem
+                label="비밀번호"
+                name="password"
+                rules={[
+                    {
+                        required: true,
+                        message: '비밀번호를 입력해주세요.',
+                    },
+                ]}
+            >
+                <StyledPassword />
+            </StyledFormItem>
+
+            <StyledFormItem
+                label="이름"
+                name="name"
+                rules={[
+                    {
+                        required: true,
+                        message: '이름을 입력해주세요.',
+                    },
+                ]}
+            >
+                <StyledInput />
+            </StyledFormItem>
+
+            <Button variant="registerBtn" type="submit">
+                회원가입
+            </Button>
+        </StyledForm>
+    );
+};
+export default CustomSignUp;

--- a/src/components/SignUp/styled.js
+++ b/src/components/SignUp/styled.js
@@ -1,0 +1,45 @@
+import { Form, Input } from 'antd';
+import styled from 'styled-components';
+import { colors } from '../../styles/colors';
+
+// Styled Components
+export const StyledForm = styled(Form)`
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    margin: 0 auto;
+    padding: 20px;
+    width: 100%;
+    // background-color: #f5f5f5;
+    border-radius: 8px;
+`;
+
+export const StyledFormItem = styled(Form.Item)`
+    margin-bottom: 24px;
+    // background-color: ${colors.main_green};
+    label {
+        font-size: 18px;
+        font-family: 'Happiness-Sans', sans-serif;
+        font-weight: 400; /* Bold */
+        color: ${colors.black};
+        width: 100px;
+        // background-color: ${colors.drak_gray};
+    }
+`;
+
+export const StyledInput = styled(Input)`
+    padding: 8px;
+    width: 300px;
+    height: 50px;
+    border-radius: 10px;
+    border: 1px solid ${colors.gray};
+`;
+
+export const StyledPassword = styled(Input.Password)`
+    padding: 8px;
+    width: 300px;
+    height: 50px;
+    border-radius: 10px;
+    border: 1px solid ${colors.gray};
+`;

--- a/src/layout/index.jsx
+++ b/src/layout/index.jsx
@@ -1,0 +1,17 @@
+import Header from '../components/Header';
+import Sidebar from '../components/Sidebar';
+import { Center, LayoutContainer } from './styled';
+
+const Layout = ({ children }) => {
+    return (
+        <LayoutContainer>
+            <Header />
+            <Center>
+                <Sidebar />
+                {children}
+            </Center>
+        </LayoutContainer>
+    );
+};
+
+export default Layout;

--- a/src/layout/styled.js
+++ b/src/layout/styled.js
@@ -1,0 +1,12 @@
+import styled from 'styled-components';
+
+export const LayoutContainer = styled.div`
+    display: flex;
+    flex-direction: column;
+    height: 100vh;
+`;
+
+export const Center = styled.div`
+    display: flex;
+    flex-direction: row;
+`;

--- a/src/pages/Login/index.jsx
+++ b/src/pages/Login/index.jsx
@@ -1,0 +1,63 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { BodyWrapper, Container, TitleWrapper } from './styled';
+import TabMenu from '../../components/TabMenu';
+import { StyledButton } from '../../components/Button/styled';
+import LessonRegister from '../../components/LessonRegister';
+import CustomLogin from '../../components/Login';
+
+const tabItems = ['전체 조회', '과거 내역'];
+
+// 예시 컴포넌트
+const AllView = () => <div>전체 조회 화면</div>;
+const PastRecords = () => <div>과거 내역 화면</div>;
+const AddPage = () => <LessonRegister />;
+
+const LoginPage = () => {
+    const navigate = useNavigate();
+    const [activeIndex, setActiveIndex] = useState(0);
+    const [currentPage, setCurrentPage] = useState('default'); // 현재 페이지 상태
+
+    const handleOnclick = () => {
+        navigate('/lesson/register');
+    };
+
+    const handleTabClick = (index) => {
+        setActiveIndex(index);
+        setCurrentPage('default'); // 탭 클릭 시 기본 페이지로 전환
+    };
+
+    // 현재 페이지에 따라 렌더링할 내용을 결정
+    const renderContent = () => {
+        switch (currentPage) {
+            case 'default':
+                return renderTabContent();
+            case 'add':
+                return <AddPage />; // 추가 페이지 컴포넌트
+            default:
+                return null;
+        }
+    };
+
+    const renderTabContent = () => {
+        switch (activeIndex) {
+            case 0:
+                return <AllView />;
+            case 1:
+                return <PastRecords />;
+            default:
+                return null;
+        }
+    };
+
+    return (
+        <Container>
+            <TitleWrapper></TitleWrapper>
+            <BodyWrapper>
+                <CustomLogin />
+            </BodyWrapper>
+        </Container>
+    );
+};
+
+export default LoginPage;

--- a/src/pages/Login/index.jsx
+++ b/src/pages/Login/index.jsx
@@ -1,55 +1,8 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { BodyWrapper, Container, TitleWrapper } from './styled';
-import TabMenu from '../../components/TabMenu';
-import { StyledButton } from '../../components/Button/styled';
-import LessonRegister from '../../components/LessonRegister';
 import CustomLogin from '../../components/Login';
 
-const tabItems = ['전체 조회', '과거 내역'];
-
-// 예시 컴포넌트
-const AllView = () => <div>전체 조회 화면</div>;
-const PastRecords = () => <div>과거 내역 화면</div>;
-const AddPage = () => <LessonRegister />;
-
 const LoginPage = () => {
-    const navigate = useNavigate();
-    const [activeIndex, setActiveIndex] = useState(0);
-    const [currentPage, setCurrentPage] = useState('default'); // 현재 페이지 상태
-
-    const handleOnclick = () => {
-        navigate('/lesson/register');
-    };
-
-    const handleTabClick = (index) => {
-        setActiveIndex(index);
-        setCurrentPage('default'); // 탭 클릭 시 기본 페이지로 전환
-    };
-
-    // 현재 페이지에 따라 렌더링할 내용을 결정
-    const renderContent = () => {
-        switch (currentPage) {
-            case 'default':
-                return renderTabContent();
-            case 'add':
-                return <AddPage />; // 추가 페이지 컴포넌트
-            default:
-                return null;
-        }
-    };
-
-    const renderTabContent = () => {
-        switch (activeIndex) {
-            case 0:
-                return <AllView />;
-            case 1:
-                return <PastRecords />;
-            default:
-                return null;
-        }
-    };
-
     return (
         <Container>
             <TitleWrapper></TitleWrapper>

--- a/src/pages/Login/styled.js
+++ b/src/pages/Login/styled.js
@@ -1,0 +1,36 @@
+import styled from 'styled-components';
+
+import { colors } from '../../styles/colors';
+import '../../styles/font.css';
+
+export const Container = styled.div`
+    width: 90vw;
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    background-color: ${colors.bg_green};
+`;
+
+export const TitleWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    flex-direction: row;
+    justify-content: space-between;
+    width: 90%;
+    height: 31px;
+    margin-top: 22px;
+    font-family: 'Happiness-Sans', sans-serif;
+    font-weight: 700; /* Bold */
+    font-size: 20pt;
+`;
+
+export const BodyWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 90%;
+    height: auto;
+    box-sizing: border-box;
+    margin-top: 22px;
+`;

--- a/src/pages/SignUp/index.jsx
+++ b/src/pages/SignUp/index.jsx
@@ -1,0 +1,66 @@
+import React, { useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { BodyWrapper, Container, TitleWrapper } from './styled';
+import TabMenu from '../../components/TabMenu';
+import { StyledButton } from '../../components/Button/styled';
+import LessonRegister from '../../components/LessonRegister';
+
+const tabItems = ['전체 조회', '과거 내역'];
+
+// 예시 컴포넌트
+const AllView = () => <div>전체 조회 화면</div>;
+const PastRecords = () => <div>과거 내역 화면</div>;
+const AddPage = () => <LessonRegister />;
+
+const Lesson = () => {
+    const navigate = useNavigate();
+    const [activeIndex, setActiveIndex] = useState(0);
+    const [currentPage, setCurrentPage] = useState('default'); // 현재 페이지 상태
+
+    const handleOnclick = () => {
+        navigate('/lesson/register');
+    };
+
+    const handleTabClick = (index) => {
+        setActiveIndex(index);
+        setCurrentPage('default'); // 탭 클릭 시 기본 페이지로 전환
+    };
+
+    // 현재 페이지에 따라 렌더링할 내용을 결정
+    const renderContent = () => {
+        switch (currentPage) {
+            case 'default':
+                return renderTabContent();
+            case 'add':
+                return <AddPage />; // 추가 페이지 컴포넌트
+            default:
+                return null;
+        }
+    };
+
+    const renderTabContent = () => {
+        switch (activeIndex) {
+            case 0:
+                return <AllView />;
+            case 1:
+                return <PastRecords />;
+            default:
+                return null;
+        }
+    };
+
+    return (
+        <Container>
+            <TitleWrapper>
+                강좌 관리
+                <StyledButton variant="addBtn" onClick={handleOnclick}>
+                    추가
+                </StyledButton>
+            </TitleWrapper>
+            <TabMenu tabItems={tabItems} activeIndex={activeIndex} onTabClick={handleTabClick} />
+            <BodyWrapper>{renderContent()}</BodyWrapper>
+        </Container>
+    );
+};
+
+export default Lesson;

--- a/src/pages/SignUp/index.jsx
+++ b/src/pages/SignUp/index.jsx
@@ -1,66 +1,16 @@
 import React, { useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { BodyWrapper, Container, TitleWrapper } from './styled';
-import TabMenu from '../../components/TabMenu';
-import { StyledButton } from '../../components/Button/styled';
-import LessonRegister from '../../components/LessonRegister';
+import CustomSignUp from '../../components/SignUp';
 
-const tabItems = ['전체 조회', '과거 내역'];
-
-// 예시 컴포넌트
-const AllView = () => <div>전체 조회 화면</div>;
-const PastRecords = () => <div>과거 내역 화면</div>;
-const AddPage = () => <LessonRegister />;
-
-const Lesson = () => {
-    const navigate = useNavigate();
-    const [activeIndex, setActiveIndex] = useState(0);
-    const [currentPage, setCurrentPage] = useState('default'); // 현재 페이지 상태
-
-    const handleOnclick = () => {
-        navigate('/lesson/register');
-    };
-
-    const handleTabClick = (index) => {
-        setActiveIndex(index);
-        setCurrentPage('default'); // 탭 클릭 시 기본 페이지로 전환
-    };
-
-    // 현재 페이지에 따라 렌더링할 내용을 결정
-    const renderContent = () => {
-        switch (currentPage) {
-            case 'default':
-                return renderTabContent();
-            case 'add':
-                return <AddPage />; // 추가 페이지 컴포넌트
-            default:
-                return null;
-        }
-    };
-
-    const renderTabContent = () => {
-        switch (activeIndex) {
-            case 0:
-                return <AllView />;
-            case 1:
-                return <PastRecords />;
-            default:
-                return null;
-        }
-    };
-
+const SignUpPage = () => {
     return (
         <Container>
-            <TitleWrapper>
-                강좌 관리
-                <StyledButton variant="addBtn" onClick={handleOnclick}>
-                    추가
-                </StyledButton>
-            </TitleWrapper>
-            <TabMenu tabItems={tabItems} activeIndex={activeIndex} onTabClick={handleTabClick} />
-            <BodyWrapper>{renderContent()}</BodyWrapper>
+            <TitleWrapper></TitleWrapper>
+            <BodyWrapper>
+                <CustomSignUp />
+            </BodyWrapper>
         </Container>
     );
 };
 
-export default Lesson;
+export default SignUpPage;

--- a/src/pages/SignUp/styled.js
+++ b/src/pages/SignUp/styled.js
@@ -1,0 +1,36 @@
+import styled from 'styled-components';
+
+import { colors } from '../../styles/colors';
+import '../../styles/font.css';
+
+export const Container = styled.div`
+    width: 90vw;
+    height: 100vh;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    background-color: ${colors.bg_green};
+`;
+
+export const TitleWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    flex-direction: row;
+    justify-content: space-between;
+    width: 90%;
+    height: 31px;
+    margin-top: 22px;
+    font-family: 'Happiness-Sans', sans-serif;
+    font-weight: 700; /* Bold */
+    font-size: 20pt;
+`;
+
+export const BodyWrapper = styled.div`
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 90%;
+    height: auto;
+    box-sizing: border-box;
+    margin-top: 22px;
+`;

--- a/src/recoil/index.js
+++ b/src/recoil/index.js
@@ -6,3 +6,8 @@ export const setUpDataState = atom({
     key: 'setupDataState',
     default: null,
 });
+
+export const authState = atom({
+    key: 'authState', // unique ID (with respect to other atoms/selectors)
+    default: false, // default value (aka initial value)
+});


### PR DESCRIPTION
# 💡 PR 요약
로그인과 회원가입 페이지 구현

## ⭐️ 관련 이슈
- closes : #14 

## 📍 작업한 내용
- 로그인 페이지
- 회원가입 페이지
- Layout 재구성하기 (layout/index.js)로 별도로 빼기

## 🔎 결과 및 이슈 공유
header 색은 기존대로 sidebar 색상과 동일합니다! 테스트를 위해서 잠깐 초록색으로 했습니다.!

- 로그인
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/d1664bf7-9bdc-4860-926d-8f9372b0db7b">
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/801ce0c7-7945-476f-b6cb-d10f5d82418d">

- 회원가입
<img width="1512" alt="image" src="https://github.com/user-attachments/assets/16bd1c6b-12c8-44be-a30e-cc9fe1ef5380">

- 회원가입 중복 오류 알림
<img width="1512" alt="스크린샷 2024-09-09 오후 12 06 52" src="https://github.com/user-attachments/assets/a246f40f-ee1e-4041-9fa7-a0430f8af3e1">


## ✔️ PR Checklist
PR이 다음 요구 사항을 충족하는지 확인하세요.

- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다. 
